### PR TITLE
Add WIPpy support for setting the inverse relationship on polymorphs

### DIFF
--- a/app/views/rails_admin/main/_form_simple_has_many.html.haml
+++ b/app/views/rails_admin/main/_form_simple_has_many.html.haml
@@ -44,7 +44,11 @@
 = form.select field.method_name, collection, { selected: selected_ids, object: form.object }, field.html_attributes.reverse_merge({data: { simplehasmany: true, options: js_data.to_json }, multiple: true})
 - if authorized?(:new, config.abstract_model) && field.inline_add
   - path_hash = { model_name: config.abstract_model.to_param, modal: true }
-  - path_hash.merge!({ associations: { field.inverse_of => (form.object.persisted? ? form.object.id : 'new') } }) if field.inverse_of
+  - form_object_id = form.object.persisted? ? form.object.id : 'new'
+  - if field.properties.association.inverse_of.polymorphic?
+    - path_hash.merge!({ config.abstract_model.to_param => { field.foreign_key => form_object_id, field.properties.association.type => form.object.model_name.name }})
+  - else
+    - path_hash.merge!({ associations: { field.inverse_of => form_object_id } }) if field.inverse_of
   = link_to "<i class=\"icon-plus icon-white\"></i> ".html_safe, '#', data: { link: new_path(path_hash) }, class: "create btn btn-info btn-sm", style: 'margin-left:10px'
 = javascript_include_tag "rails_admin/routes"
 = javascript_include_tag "rails_admin/ra.simple-has-many"


### PR DESCRIPTION
This is hacked together using some console debugging to drill down into object trees on `field` without a solid understanding of the RailsAdmin `Field` object but the intent is creating new `has_many` association objects that point back to their polymorphic`belongs_to` properly.
